### PR TITLE
 rsyncd.conf server config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Variable options (on run)
 
 |     Parameter     | Function |
 | :---------------: | -------- |
-| `USERNAME`        | the `rsync` username. defaults to `root`|
-| `PASSWORD`        | the `rsync` password. defaults to `root`|
+| `USERNAME`        | the `rsync` username. defaults to `user`|
+| `PASSWORD`        | the `rsync` password. defaults to `pass`|
 | `AUTHORIZED_KEYS` | the `ssh` key (for root user). defaults empty |
 | `VOLUME`   | the path for `rsync`. defaults to `/data`|
 | `PUID`     | UserID used to transfer files when running the rsync . defaults to `root`|

--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ total size is 0  speedup is 0.00
 
 Variable options (on run)
 
-* `USERNAME` - the `rsync` username. defaults to `user`
-* `PASSWORD` - the `rsync` password. defaults to `pass`
-* `VOLUME`   - the path for `rsync`. defaults to `/data`
-* `ALLOW`    - space separated list of allowed sources. defaults to `10.0.0.0/8 192.168.0.0/16 172.16.0.0/12 127.0.0.1/32`.
+|     Parameter     | Function |
+| :---------------: | -------- |
+| `USERNAME`        | the `rsync` username. defaults to `root`|
+| `PASSWORD`        | the `rsync` password. defaults to `root`|
+| `AUTHORIZED_KEYS` | the `ssh` key (for root user). defaults empty |
+| `VOLUME`   | the path for `rsync`. defaults to `/data`|
+| `PUID`     | UserID used to transfer files when running the rsync . defaults to `root`|
+| `GUID`     | GroupID used to transfer files when running the rsync . defaults to `root`|
+| `DENY`     | space separated list of allowed sources. defaults to `*`|
+| `ALLOW`    | space separated list of allowed sources. defaults to `10.0.0.0/8 192.168.0.0/16 172.16.0.0/12 127.0.0.1/32`.|
+| `RO`     | `rsync` volume read only. defaults to `false`|
+| `CUSTOMCONFIG` | rsyncd.conf custom config for subsection volume (`\n\t` for new line ex: `uid = root\n\tgid = root`). defaults empty |
 
 ### Simple server on port 873
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -e
-
+# AUTHORIZED_KEYS
 USERNAME=${USERNAME:-user}
 PASSWORD=${PASSWORD:-pass}
-ALLOW=${ALLOW:-10.0.0.0/8 192.168.0.0/16 172.16.0.0/12 127.0.0.1/32}
 VOLUME=${VOLUME:-/data}
+PUID=${PUID:-root}
+GUID=${GUID:-root}
+DENY=${DENY:-"*"}
+ALLOW=${ALLOW:-10.0.0.0/8 192.168.0.0/16 172.16.0.0/12 127.0.0.1/32}
+RO=${RO:-false}
+# CUSTOMCONFIG
 
 
 setup_sshd(){
@@ -14,6 +19,9 @@ setup_sshd(){
     else
 		mkdir -p /root/.ssh
 		chown root:root /root/.ssh
+		if [ ! -z "$AUTHORIZED_KEYS" ]; then
+			echo "$AUTHORIZED_KEYS" > /root/.ssh/authorized_keys
+		fi
     fi
     chmod 750 /root/.ssh
     echo "root:$PASSWORD" | chpasswd
@@ -29,16 +37,20 @@ max connections = 10
 port = 873
 
 [volume]
-	uid = root
-	gid = root
-	hosts deny = *
+	uid = ${PUID}
+	gid = ${GUID}
+	hosts deny = ${DENY}
 	hosts allow = ${ALLOW}
-	read only = false
+	read only = ${RO}
 	path = ${VOLUME}
 	comment = ${VOLUME} directory
 	auth users = ${USERNAME}
 	secrets file = /etc/rsyncd.secrets
 EOF
+
+if [ ! -z "$CUSTOMCONFIG" ]; then
+	echo -e "\t${CUSTOMCONFIG}" >> /etc/rsyncd.conf
+fi
 }
 
 


### PR DESCRIPTION
> see pull request #13 branch renamed on my repository

added option to configure /etc/rsyncd.conf and create authorized_keys file from the environment vars
new env config :
- `AUTHORIZED_KEYS`
- `PUID`
- `GUID`
- `DENY`
- `RO`
- `CUSTOMCONFIG`

update files:  
- entrypoint.sh
- README.md  (Usage: Parameter->Function)

