### PR TITLE
Check authorized keys owner/group/permissions before running chmod/chown

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ docker run \
 ### Over SSH
 
 If you would like to connect over ssh, you may mount your public key or
-`authorized_keys` file to `/root/.ssh/authorized_keys`.
+`authorized_keys` file to `/root/.ssh/authorized_keys`. This file
+must have owner root, group root, and 400 octal permissions.
+
+Alternatively, you may specify the `AUTHORIZED_KEYS` environment variable.
 
 Without setting up an `authorized_keys` file, you will be propted for the
 password (which was specified in the `PASSWORD` variable).


### PR DESCRIPTION
Fixes #4

Check `/root/.ssh` and (if it exists) `/root/.ssh/authorized_keys` existing owner, group, and permission before attempting to adjust with `chown` and `chmod`. This should allow k8s deployments using configmaps and other deployment mechanisms which mount a read only authorized_keys file to successfully run.

Note that the provided authorized_keys file __must__ already have the correct owner (root), group (root), and permissions (400).