### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ setup_rsyncd(){
     echo "$USERNAME:$PASSWORD" > /etc/rsyncd.secrets
     chmod 0400 /etc/rsyncd.secrets
     [ -f /etc/rsyncd.conf ] || cat > /etc/rsyncd.conf <<EOF
-log file = /dev/stdout
+log file = /dev/null
 timeout = 300
 max connections = 10
 port = 873


### PR DESCRIPTION
Log output was causing rsync client not connecting:

rsync -e "ssh -p 13337 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" rsync://root@server 
Warning: Permanently added '[server]:13337' (ED25519) to the list of known hosts. 
root@server's password: 
rsync: server sent "2024/09/25 19:15:38 [477] name lookup failed for 172.30.30.100: Name or service not known" rather than greeting 
rsync error: error starting client-server protocol (code 5) at main.c(1863) [Receiver=3.2.7]

https://serverfault.com/questions/826854/rsync-via-remote-shell-connection-server-sends-rsync-log-message-rather-than-gr