### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ setup_rsyncd(){
     echo "$USERNAME:$PASSWORD" > /etc/rsyncd.secrets
     chmod 0400 /etc/rsyncd.secrets
     [ -f /etc/rsyncd.conf ] || cat > /etc/rsyncd.conf <<EOF
-log file = /dev/stdout
+log file = /dev/stderr
 timeout = 300
 max connections = 10
 port = 873


### PR DESCRIPTION
some hosts can't connect because logging is logged to stdout instead of stderr causing clients to be confused about welcome message.

rsync: server sent "2024/09/25 19:21:37 [519] name lookup failed for 172.30.30.100: Name or service not known" rather than greeting
rsync error: error starting client-server protocol (code 5) at main.c(1863) [Receiver=3.2.7]
